### PR TITLE
修复flutter 1.7.9 不兼容问题

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // 使用 IntelliSense 了解相关属性。
+  // 悬停以查看现有属性的描述。
+  // 欲了解更多信息，请访问: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Flutter",
+      "request": "launch",
+      "type": "dart",
+      "program": "example/lib/main.dart"
+      // "args": ["--target-platform", "android-arm64"]
+    }
+  ]
+}

--- a/android/.classpath
+++ b/android/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin/default"/>
+</classpath>

--- a/android/.project
+++ b/android/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>amap_base</name>
+	<comment>Project amap_base created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(5.4))
+connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/android/src/main/kotlin/me/yohom/amapbase/map/MapHandlers.kt
+++ b/android/src/main/kotlin/me/yohom/amapbase/map/MapHandlers.kt
@@ -183,17 +183,24 @@ object ClearMap : MapMethodHandler {
 }
 
 object OpenOfflineManager : MapMethodHandler {
-
-    override fun with(map: AMap): MapMethodHandler {
-        return this
-    }
-
-    override fun onMethodCall(p0: MethodCall?, p1: MethodChannel.Result?) {
+    override fun onMethodCall(p0: MethodCall, p1: MethodChannel.Result) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         AMapBasePlugin.registrar.activity().startActivity(
                 Intent(AMapBasePlugin.registrar.activity(),
                         OfflineMapActivity::class.java)
         )
     }
+
+    override fun with(map: AMap): MapMethodHandler {
+        return this
+    }
+
+//    override  fun onMethodCall(p0: MethodCall?, p1: MethodChannel.Result?) {
+//        AMapBasePlugin.registrar.activity().startActivity(
+//                Intent(AMapBasePlugin.registrar.activity(),
+//                        OfflineMapActivity::class.java)
+//        )
+//    }
 }
 
 object SetLanguage : MapMethodHandler {

--- a/android/src/main/kotlin/me/yohom/amapbase/search/SearchHandlers.kt
+++ b/android/src/main/kotlin/me/yohom/amapbase/search/SearchHandlers.kt
@@ -284,7 +284,11 @@ object CalculateDriveRoute : SearchMethodHandler {
 }
 
 object DistanceSearchHandler : SearchMethodHandler {
-    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result?) {
+//    override fun onMethodCall(p0: MethodCall, p1: MethodChannel.Result) {
+//        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+//    }
+
+    override fun onMethodCall(p0: MethodCall, p1: MethodChannel.Result) {
         val search = DistanceSearch(AMapBasePlugin.registrar.context())
         search.setDistanceSearchListener { distanceResult, i ->
             search.setDistanceSearchListener(null)
@@ -292,15 +296,15 @@ object DistanceSearchHandler : SearchMethodHandler {
                 val list = distanceResult.distanceResults.map {
                     it.distance.toInt()
                 }
-                result?.success(list)
+                p1.success(list)
             } else {
-                result?.error("测量失败 code ==> $i", null, null)
+                p1.error("测量失败 code ==> $i", null, null)
             }
         }
 
-        val origins = call.argument<List<Map<String, Any>>>("origin")!!
-        val target = call.argument<Map<String, Any>>("target")!!
-        val type = call.argument<Int>("type")!!
+        val origins = p0.argument<List<Map<String, Any>>>("origin")!!
+        val target = p0.argument<Map<String, Any>>("target")!!
+        val type = p0.argument<Int>("type")!!
 
         search.calculateRouteDistanceAsyn(DistanceSearch.DistanceQuery().apply {
             this.origins = origins.map {

--- a/example/android/.project
+++ b/example/android/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>android</name>
+	<comment>Project android created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/example/android/.settings/org.eclipse.buildship.core.prefs
+++ b/example/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(5.4))
+connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/example/android/app/.classpath
+++ b/example/android/app/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin/default"/>
+</classpath>

--- a/example/android/app/.project
+++ b/example/android/app/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>app</name>
+	<comment>Project app created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/example/android/app/.settings/org.eclipse.buildship.core.prefs
+++ b/example/android/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1


### PR DESCRIPTION
***OpenOfflineManager等问题***
升级1.7.9后禁用 "args": ["--target-platform", "android-arm64"]出翔的兼容问题
`MapHandlers.kt: (185, 1): Object 'OpenOfflineManager' is not abstract and does not implement abstract member @UiThread public abstract fun onMethodCall(@NonNull p0: MethodCall, @NonNull p1: MethodChannel.Result): Unit defined in me.yohom.amapbase.MapMethodHandler`
