### PR TITLE
Fix #175 & update dependencies

### DIFF
--- a/base/android/build.gradle
+++ b/base/android/build.gradle
@@ -2,14 +2,14 @@ group 'me.yohom.amapbase'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.3.41'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/base/android/build.gradle
+++ b/base/android/build.gradle
@@ -40,10 +40,10 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.0-beta01'
+    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.2.71'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.3.41'
 
     implementation 'com.amap.api:navi-3dmap:6.5.0_3dmap6.5.0'
     implementation 'com.amap.api:search:6.5.0.1'

--- a/base/android/build.gradle
+++ b/base/android/build.gradle
@@ -2,7 +2,7 @@ group 'me.yohom.amapbase'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '1.3.40'
     repositories {
         google()
         jcenter()

--- a/base/android/src/main/kotlin/me/yohom/amapbase/map/MapHandlers.kt
+++ b/base/android/src/main/kotlin/me/yohom/amapbase/map/MapHandlers.kt
@@ -188,7 +188,7 @@ object OpenOfflineManager : MapMethodHandler {
         return this
     }
 
-    override fun onMethodCall(p0: MethodCall?, p1: MethodChannel.Result?) {
+    override fun onMethodCall(p0: MethodCall, p1: MethodChannel.Result) {
         AMapBasePlugin.registrar.activity().startActivity(
                 Intent(AMapBasePlugin.registrar.activity(),
                         OfflineMapActivity::class.java)

--- a/base/android/src/main/kotlin/me/yohom/amapbase/search/SearchHandlers.kt
+++ b/base/android/src/main/kotlin/me/yohom/amapbase/search/SearchHandlers.kt
@@ -246,17 +246,18 @@ object SearchRoutePoiPolygon : SearchMethodHandler {
 
 object CalculateDriveRoute : SearchMethodHandler {
 
+
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         // 规划参数
-        val param = call.argument<String>("routePlanParam")!!.parseFieldJson<RoutePlanParam>()
+        val param :RoutePlanParam= call.argument<String>("routePlanParam")!!.parseFieldJson()
 
         log("方法calculateDriveRoute android端参数: routePlanParam -> $param")
 
         val routeQuery = RouteSearch.DriveRouteQuery(
                 RouteSearch.FromAndTo(param.from.toLatLonPoint(), param.to.toLatLonPoint()),
                 param.mode,
-                param.passedByPoints?.map { it.toLatLonPoint() },
-                param.avoidPolygons?.map { list -> list.map { it.toLatLonPoint() } },
+                param.passedByPoints?.map { value->  value.toLatLonPoint() },
+                param.avoidPolygons?.map { list -> list?.map { value->  value.toLatLonPoint() } },
                 param.avoidRoad
         )
         RouteSearch(AMapBasePlugin.registrar.context()).run {
@@ -281,10 +282,12 @@ object CalculateDriveRoute : SearchMethodHandler {
             calculateDriveRouteAsyn(routeQuery)
         }
     }
+
+
 }
 
 object DistanceSearchHandler : SearchMethodHandler {
-    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result?) {
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         val search = DistanceSearch(AMapBasePlugin.registrar.context())
         search.setDistanceSearchListener { distanceResult, i ->
             search.setDistanceSearchListener(null)
@@ -303,8 +306,8 @@ object DistanceSearchHandler : SearchMethodHandler {
         val type = call.argument<Int>("type")!!
 
         search.calculateRouteDistanceAsyn(DistanceSearch.DistanceQuery().apply {
-            this.origins = origins.map {
-                it.toLatlng().toLatLonPoint()
+            this.origins = origins.map {value->
+                value.toLatlng().toLatLonPoint()
             }.toMutableList()
             this.destination = target.toLatlng().toLatLonPoint()
             this.type = type

--- a/base/example/android/app/build.gradle
+++ b/base/example/android/app/build.gradle
@@ -82,6 +82,6 @@ flutter {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.0-alpha4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha4'
+    androidTestImplementation 'androidx.test:runner:1.3.0-alpha01'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0-alpha01'
 }

--- a/base/example/android/build.gradle
+++ b/base/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '1.3.40'
     repositories {
         jcenter()
         google()

--- a/base/example/android/build.gradle
+++ b/base/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.3.41'
     repositories {
         jcenter()
         google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/base/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/base/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Thu Jul 11 15:51:13 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
This are two main changes in this PR:
1. update dependencies, such as Kotlin(1.3.40).
2. fix #175. This bug was caused by new behavior in Android native pattern.The params in `onMethodCall` which belongs to  `MethodCallHandler` are marked by `@NonNull` now.
Besides, the field `param` in  `CalculateDriveRoute` should be specified type , otherwise, compile error.